### PR TITLE
Update sample_data_simple.json

### DIFF
--- a/src/sample_data_simple.json
+++ b/src/sample_data_simple.json
@@ -21,6 +21,7 @@
         },
         {
           "name": "proxy-prod",
+          "metadata": {},
           "renderer": "focusedChild",
           "class": "normal"
         }


### PR DESCRIPTION
fixed bug: if you click on proxy-prod node, you get error and panel with detailed information does not appear since metadata is not defined