### PR TITLE
Update detailsPanelNode.jsx

### DIFF
--- a/src/components/detailsPanelNode.jsx
+++ b/src/components/detailsPanelNode.jsx
@@ -51,7 +51,7 @@ class DetailsPanelNode extends React.Component {
         </div>
         <Notices notices={notices} />
         { node && !node.isEntryNode() ?
-          <DetailsSubpanelClusters discovery={node.metadata.discovery} clusters={node.clusters} region={this.state.region} />
+          <DetailsSubpanelClusters clusters={node.clusters} region={this.state.region} />
         : undefined }
         { node && !node.isEntryNode() ?
         <DetailsSubpanel title="Incoming Connections">


### PR DESCRIPTION
fix: no need to depend on metadata. Pane fails to display if metadata is not defined for a node