### PR TITLE
Added a click handler so the expand/collapse chevron will change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ node_modules
 
 # Typings
 *.ts
+
+# Temporary Files and Backups
+*.swp
+*.*~

--- a/src/components/detailsPanelNode.jsx
+++ b/src/components/detailsPanelNode.jsx
@@ -51,14 +51,14 @@ class DetailsPanelNode extends React.Component {
         </div>
         <Notices notices={notices} />
         { node && !node.isEntryNode() ?
-          <DetailsSubpanelClusters clusters={node.clusters} region={this.state.region} />
+          <DetailsSubpanelClusters clusters={node.clusters} region={this.state.region} expanded={true} />
         : undefined }
         { node && !node.isEntryNode() ?
-        <DetailsSubpanel title="Incoming Connections">
+        <DetailsSubpanel title="Incoming Connections" badge={node.incomingConnections.length}>
           <ConnectionList key={node.getName()} connections={node.incomingConnections} direction="incoming" nodeClicked={clickedNode => this.props.nodeClicked(clickedNode)} />
         </DetailsSubpanel>
         : undefined }
-        <DetailsSubpanel title="Outgoing Connections">
+        <DetailsSubpanel title="Outgoing Connections" badge={node.outgoingConnections.length}>
           <ConnectionList key={node.getName()} connections={node.outgoingConnections} direction="outgoing" nodeClicked={clickedNode => this.props.nodeClicked(clickedNode)} />
         </DetailsSubpanel>
       </div>

--- a/src/components/detailsSubpanel.jsx
+++ b/src/components/detailsSubpanel.jsx
@@ -2,16 +2,16 @@
 
 import React from 'react';
 
-class NodeDetailsSubpanel extends React.Component {
+class DetailsSubpanel extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
-      expanded: this.props.expanded ? this.props.expanded : false
+      expanded: props.expanded ? props.expanded : false
     };
   }
 
-  changeState (newState) {
-    this.setState(newState);
+  componentWillReceiveProps (nextProps) {
+    this.setState({ expanded: nextProps.expanded });
   }
 
   render () {
@@ -31,7 +31,7 @@ class NodeDetailsSubpanel extends React.Component {
         <div className="panel panel-default">
           <div className="panel-heading" role="tab" id={headingId}>
             <h4 className="panel-title">
-              <a role="button" data-toggle="collapse" href={`#${collapseId}`} aria-controls={collapseId} className={`accordion-toggle${expanded ? '' : ' collapsed'}`} onClick={() => this.changeState({ expanded: !expanded })}>
+              <a role="button" data-toggle="collapse" href={`#${collapseId}`} aria-controls={collapseId} className={`accordion-toggle${expanded ? '' : ' collapsed'}`} onClick={() => this.setState({ expanded: !expanded })}>
                 <span className={iconClass} style={iconStyle}></span> {this.props.title.toUpperCase()} {badge ? <span className="badge">{badge}</span> : undefined}
               </a>
             </h4>
@@ -49,10 +49,10 @@ class NodeDetailsSubpanel extends React.Component {
   }
 }
 
-NodeDetailsSubpanel.propTypes = {
+DetailsSubpanel.propTypes = {
   title: React.PropTypes.string.isRequired,
   expanded: React.PropTypes.bool,
   badge: React.PropTypes.number
 };
 
-export default NodeDetailsSubpanel;
+export default DetailsSubpanel;

--- a/src/components/detailsSubpanel.jsx
+++ b/src/components/detailsSubpanel.jsx
@@ -3,13 +3,24 @@
 import React from 'react';
 
 class NodeDetailsSubpanel extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      expanded: this.props.expanded ? this.props.expanded : false
+    };
+  }
+
+  changeState (newState) {
+    this.setState(newState);
+  }
+
   render () {
     const badge = this.props.badge;
     const title = this.props.title.replace(/\s/g, '_');
     const headingId = `${title}Heading`;
     const collapseId = `collapse${title}`;
 
-    const expanded = this.props.expanded;
+    const expanded = this.state.expanded;
     const iconClass = `glyphicon ${expanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right'}`;
     const iconStyle = {
       fontSize: '12px',
@@ -20,7 +31,7 @@ class NodeDetailsSubpanel extends React.Component {
         <div className="panel panel-default">
           <div className="panel-heading" role="tab" id={headingId}>
             <h4 className="panel-title">
-              <a role="button" data-toggle="collapse" href={`#${collapseId}`} aria-controls={collapseId} className={`accordion-toggle${expanded ? ' collapsed' : ''}`}>
+              <a role="button" data-toggle="collapse" href={`#${collapseId}`} aria-controls={collapseId} className={`accordion-toggle${expanded ? '' : ' collapsed'}`} onClick={() => this.changeState({ expanded: !expanded })}>
                 <span className={iconClass} style={iconStyle}></span> {this.props.title.toUpperCase()} {badge ? <span className="badge">{badge}</span> : undefined}
               </a>
             </h4>

--- a/src/components/detailsSubpanelClusters.jsx
+++ b/src/components/detailsSubpanelClusters.jsx
@@ -23,7 +23,7 @@ class DetailsSubpanelClusters extends React.Component {
 
   render () {
     return (
-      <DetailsSubpanel title="Clusters" expanded={true}>
+      <DetailsSubpanel title="Clusters" expanded={this.props.expanded} badge={this.state.clusters.length}>
         { this.state.clusters ?
         <div>
           <div className="details-panel-subtitle"><span style={{ fontWeight: 600 }}>Traffic by Cluster</span></div>


### PR DESCRIPTION
The glyphicon used in the title of the details subpanel component doesn't actually change in response to a click.  I added a simple click handler so the expand-collapse chevron will change on the `detailsSubpanel` component.  Also, useful when embedding inside another JS framework (e.g. AngularJS). The expand-collapse click kept getting "hijacked."