### PR TITLE
Compensates for bug in window.history.pushState where URLs with a colon cause a DOM exception

### DIFF
--- a/src/components/detailsPanelNode.jsx
+++ b/src/components/detailsPanelNode.jsx
@@ -72,7 +72,6 @@ DetailsPanelNode.propTypes = {
   zoomCallback: React.PropTypes.func.isRequired,
   node: React.PropTypes.object.isRequired,
   nodeClicked: React.PropTypes.func,
-  nodeSelected: React.PropTypes.bool.isRequired,
   region: React.PropTypes.string
 };
 

--- a/src/components/trafficFlow.jsx
+++ b/src/components/trafficFlow.jsx
@@ -189,7 +189,7 @@ class TrafficFlow extends React.Component {
         const highlightedObjectName = nextState.highlightedObject && nextState.highlightedObject.getName();
         const state = {
           title: document.title,
-          url: nextState.currentView.join('/') + (highlightedObjectName ? `?highlighted=${highlightedObjectName}` : ''),
+          url: `/${nextState.currentView.join('/')}${highlightedObjectName ? `?highlighted=${highlightedObjectName}` : ''}`,
           selected: nextState.currentView,
           highlighted: highlightedObjectName
         };


### PR DESCRIPTION
Compensates for bug in window.history.pushState where URLs with a colon cause a DOM exception. Removed last remnant of nodeSelected from detailNodePanel.